### PR TITLE
Decoupling from circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val scala3Version = "3.3.0"
 val circeVersion = "0.14.1"
 val scalatestVersion = "3.2.9"
 
-ThisBuild / organization := "io.github.jqscala"
+ThisBuild / organization := "jqscala"
 ThisBuild / homepage := Some(url("https://github.com/jqscala/jqscala"))
 ThisBuild / licenses := List("Creative Commons" -> url("https://creativecommons.org/licenses/by-nc-sa/4.0/"))
 ThisBuild / developers := List(
@@ -22,10 +22,12 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "jqscala",
+    version := "0.1.0-DECOUPLING",
 
     scalaVersion := scala3Version,
 
     Test / packageBin / publishArtifact := true,
+    Test / packageSrc / publishArtifact := true,
 
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,

--- a/src/main/scala/jq/Json.scala
+++ b/src/main/scala/jq/Json.scala
@@ -1,19 +1,17 @@
 package jq
 
-import io.circe._
+trait Json[J]:
+  
+    extension (i: Int)
+        def num: J
 
-object IsArray: 
-    def unapply(v: Json): Option[Vector[Json]] = 
-        v.asArray
+    extension (i: String)
+        def str: J
 
-object IsObject: 
-    def unapply(v: Json): Option[JsonObject] = 
-        v.asObject
+    def obj(kv: (String, J)*): J
 
-object IsString: 
-    def unapply(v: Json): Option[String] = 
-        v.asString
+    def arr(elems: J*): J
 
-object IsInt: 
-    def unapply(v: Json): Option[Int] = 
-        v.asNumber.flatMap(_.toInt)
+object Json:
+
+    def apply[J](using j: Json[J]): Json[J] = j

--- a/src/main/scala/jq/TypeError.scala
+++ b/src/main/scala/jq/TypeError.scala
@@ -1,10 +1,8 @@
 package jq
 
-import io.circe.Json
-
-enum TypeError: 
-    case CannotIterateOver(j: Json)
-    case CannotIndexObjectWith(j: Json)
-    case CannotIndex(what: Json, _with: Json)
-    case Custom(msg: String = "")
+enum TypeError[J: Json]: 
+    case CannotIterateOver[J: Json](j: J) extends TypeError[J]
+    case CannotIndexObjectWith[J: Json](j: J) extends TypeError[J]
+    case CannotIndex[J: Json](what: J, _with: J) extends TypeError[J]
+    case Custom[J: Json](msg: String = "") extends TypeError[J]
 

--- a/src/main/scala/jq/std/CirceJson.scala
+++ b/src/main/scala/jq/std/CirceJson.scala
@@ -1,0 +1,18 @@
+package jq
+package std
+
+import io.circe.{Json => CJson}
+
+given Json[CJson] with
+
+    extension (i: Int)
+        def num: CJson = CJson.fromInt(i)
+    
+    extension (i: String)
+        def str: CJson = CJson.fromString(i)
+
+    def obj(kv: (String, CJson)*): CJson = 
+        CJson.obj(kv*)
+
+    def arr(elems: CJson*): CJson =
+        CJson.arr(elems*)

--- a/src/main/scala/jq/std/Json.scala
+++ b/src/main/scala/jq/std/Json.scala
@@ -1,0 +1,20 @@
+package jq
+package std
+
+import io.circe._
+
+object IsArray: 
+    def unapply(v: Json): Option[Vector[Json]] = 
+        v.asArray
+
+object IsObject: 
+    def unapply(v: Json): Option[JsonObject] = 
+        v.asObject
+
+object IsString: 
+    def unapply(v: Json): Option[String] = 
+        v.asString
+
+object IsInt: 
+    def unapply(v: Json): Option[Int] = 
+        v.asNumber.flatMap(_.toInt)

--- a/src/main/scala/jq/std/StdSem.scala
+++ b/src/main/scala/jq/std/StdSem.scala
@@ -1,11 +1,12 @@
 package jq
+package std
 
 import io.circe.Json
 import io.circe.syntax._
 
 object StdSem: 
 
-    type Filter = LazyList[Json] => LazyList[Json|TypeError]
+    type Filter = LazyList[Json] => LazyList[Json | TypeError[Json]]
 
     given Jq[Filter] with
         def id: Filter = identity
@@ -25,7 +26,7 @@ object StdSem:
                 val elements = f(LazyList(v))
                 elements
                     .find:
-                        case e: TypeError => true
+                        case e: TypeError[Json] => true
                         case _ => false 
                     .fold(
                         LazyList(Json.arr(elements.toList.map:
@@ -33,7 +34,7 @@ object StdSem:
                             case _ => ??? /*should not happen*/ 
                         *))
                     ):
-                        case e: TypeError => LazyList(e)
+                        case e: TypeError[Json] => LazyList(e)
                         case _ => ??? // should not happen
 
         def error(msg: String): Filter = 
@@ -44,7 +45,7 @@ object StdSem:
             def |(f2: Filter): Filter = 
                 _.flatMap: v => 
                     f1(LazyList(v)).flatMap:
-                        case e: TypeError => LazyList(e)
+                        case e: TypeError[Json] => LazyList(e)
                         case j: Json => f2(LazyList(j)) 
 
             def concat(f2: Filter): Filter = 
@@ -54,21 +55,21 @@ object StdSem:
             private def indexArray(idx: Int): Filter =
                 _.flatMap: v1 => 
                     f1(LazyList(v1)).flatMap:
-                        case e: TypeError => LazyList(e)
+                        case e: TypeError[Json] => LazyList(e)
                         case IsArray(vec) => LazyList(vec.lift(idx).getOrElse(Json.Null))
                         case v2: Json => LazyList(TypeError.CannotIndex(v2, idx.asJson)) 
                             
             private def indexObj(key: String): Filter =
                 _.flatMap: v1 => 
                     f1(LazyList(v1)).flatMap:
-                        case e: TypeError => LazyList(e)
+                        case e: TypeError[Json] => LazyList(e)
                         case IsObject(obj) => LazyList(obj(key).getOrElse(Json.Null))
                         case v2: Json => LazyList(TypeError.CannotIndex(v2, key.asJson))     
 
             def index(keyF: Filter): Filter = 
                 _.flatMap: v => 
                     keyF(LazyList(v)) flatMap:
-                        case e: TypeError => LazyList(e)
+                        case e: TypeError[Json] => LazyList(e)
                         case IsInt(idx) => indexArray(idx)(LazyList(v))
                         case IsString(str) => indexObj(str)(LazyList(v))
                         case k: Json => LazyList(TypeError.CannotIndex(what = v, _with = k))
@@ -77,6 +78,6 @@ object StdSem:
                 _ flatMap: j => 
                     f1(LazyList(j)) flatMap:
                         case j: Json => LazyList(j)
-                        case e: TypeError => 
+                        case e: TypeError[Json] => 
                             f2(LazyList(Json.fromString(e.toString)))
 

--- a/src/test/scala/jq/IdentitySpec.scala
+++ b/src/test/scala/jq/IdentitySpec.scala
@@ -1,14 +1,14 @@
 package jq
 
-trait IdentitySpec[R](using Jq[R], RunnableFilter[R]):
+trait IdentitySpec[R: Jq, J: Json](using RunnableFilter[R, J]):
     self: JqBaseSpec =>
 
     "The identity filter" should "return the same input" in:
 
-        List("a", "b", "c")
-            .through[String](id) shouldBe 
-                List("a", "b", "c")
+        List("a".str, "b".str, "c".str)
+            .throughJson(id) shouldBe 
+                List("a".str, "b".str, "c".str)
 
-        List[String]()
-            .through[String](id) shouldBe 
+        List[J]()
+            .throughJson(id) shouldBe 
                 List()

--- a/src/test/scala/jq/IteratorSpec.scala
+++ b/src/test/scala/jq/IteratorSpec.scala
@@ -1,18 +1,15 @@
 package jq
 
-import io.circe.Json
-import io.circe.syntax._
-
-trait IteratorSpec[R](using Jq[R], RunnableFilter[R]):
+trait IteratorSpec[R: Jq, J: Json](using RunnableFilter[R, J]):
     self: JqBaseSpec =>
 
     "The iterator filter" should "expand objects and arrays" in:
 
-        List(Json.obj("a" -> 1.asJson, "b" -> 2.asJson))
-            .through[Int](iterator) shouldBe 
-                List(1, 2)
+        List(Json[J].obj("a" -> 1.num, "b" -> 2.num))
+            .throughJson(iterator) shouldBe 
+                List(1.num, 2.num)
 
-        List(List(1,2,3))
-            .through[Int](iterator) shouldBe 
-                List(1, 2, 3)
+        List(Json[J].arr(1.num, 2.num, 3.num))
+            .throughJson(iterator) shouldBe 
+                List(1.num, 2.num, 3.num)
 

--- a/src/test/scala/jq/JqSpec.scala
+++ b/src/test/scala/jq/JqSpec.scala
@@ -1,6 +1,6 @@
 package jq
 
-class JqSpec[R](using Jq[R], RunnableFilter[R]) extends JqBaseSpec 
-    with IdentitySpec[R]
-    with IteratorSpec[R]
-    with MapSpec[R]
+class JqSpec[R: Jq, J: Json](using RunnableFilter[R, J]) extends JqBaseSpec 
+    with IdentitySpec[R, J]
+    with IteratorSpec[R, J]
+    with MapSpec[R, J]

--- a/src/test/scala/jq/MapSpec.scala
+++ b/src/test/scala/jq/MapSpec.scala
@@ -1,12 +1,12 @@
 package jq
 
-trait MapSpec[R](using Jq[R], RunnableFilter[R]):
+trait MapSpec[R: Jq, J: Json](using RunnableFilter[R, J]):
     self: JqBaseSpec =>
 
     "Map" should "work" in: 
-        val input = List(List(1,2,3), List(), List(1))
+        val input = List(Json[J].arr(1.num,2.num,3.num), Json[J].arr(), Json[J].arr(1.num))
 
-        input.through[List[Int]](map(id)) shouldBe input 
+        input.throughJson(map(id)) shouldBe input 
 
-        input.through[List[String]](map(str("dummy"))) shouldBe 
-            List(List("dummy","dummy","dummy"), List(), List("dummy"))
+        input.throughJson(map(str("dummy"))) shouldBe 
+            List(Json[J].arr("dummy".str,"dummy".str,"dummy".str), Json[J].arr(), Json[J].arr("dummy".str))

--- a/src/test/scala/jq/RunnableFilter.scala
+++ b/src/test/scala/jq/RunnableFilter.scala
@@ -1,25 +1,5 @@
 package jq
 
-import io.circe.{`export` as _, *}
-import io.circe.generic.auto.*
-import io.circe.parser._
-import io.circe.syntax._
-
-trait RunnableFilter[R]:
-    extension (input: List[Json])
-        def throughJson(r: R): List[Json | TypeError]
-
-    extension [A: Encoder](st: List[A])
-        def through[B: Decoder](f: R): List[B | TypeError] = 
-            st.map(_.asJson)
-                .throughJson(f)
-                .map:
-                    case j: Json => j.as[B].fold(t => throw t, identity)
-                    case t: TypeError => t
-
-object RunnableFilter:
-
-    given RunnableFilter[StdSem.Filter] with
-        extension (input: List[Json])
-            def throughJson(r: StdSem.Filter): List[Json | TypeError] = 
-                r(LazyList(input*)).toList
+trait RunnableFilter[R, J: Json]:
+    extension (input: List[J])
+        def throughJson(r: R): List[J | TypeError[J]]

--- a/src/test/scala/jq/StdSpec.scala
+++ b/src/test/scala/jq/StdSpec.scala
@@ -1,5 +1,0 @@
-package jq 
-
-import StdSem.given
-
-class StdSpec extends JqSpec[StdSem.Filter]

--- a/src/test/scala/jq/std/StdRunnable.scala
+++ b/src/test/scala/jq/std/StdRunnable.scala
@@ -1,0 +1,9 @@
+package jq
+package std
+    
+import io.circe._
+
+given RunnableFilter[StdSem.Filter, Json] with
+    extension (input: List[Json])
+        def throughJson(r: StdSem.Filter): List[Json | TypeError[Json]] = 
+            r(LazyList(input*)).toList

--- a/src/test/scala/jq/std/StdSpec.scala
+++ b/src/test/scala/jq/std/StdSpec.scala
@@ -1,0 +1,6 @@
+package jq
+package std 
+
+import StdSem.given
+
+class StdSpec extends JqSpec[StdSem.Filter, io.circe.Json]


### PR DESCRIPTION
Remove circe Json references from the Jq type class and public API, in order to make it compatible with [Jq-ZIO](https://github.com/jqscala/jq-zio).